### PR TITLE
Setup all known routes for 'location' and setup basic schema

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -22,8 +22,8 @@ app.get("/", (req, res) => {
 })
 
 app.use("/api/forecast", require("./routes/forecast"));
-app.use("api/location", require("./routes/location"));
-app.use ("api/alerts", require("./routes/alert"));
+app.use("/api/location", require("./routes/location"));
+app.use ("/api/alerts", require("./routes/alert"));
 
 // start listening on server
 const port = process.env.PORT;

--- a/backend/models/Location.js
+++ b/backend/models/Location.js
@@ -3,7 +3,18 @@ const { model, Schema } = mongoose;
 
 const LocationSchema = Schema(
   {
-    
+    type: {
+      type: String,
+      enum: ['Point'],
+      required: true
+    },
+    coordinates: {
+      type: [Number],
+      required: true
+    },
+    name: {
+        type: String
+    }
   }
 )
 

--- a/backend/routes/location.js
+++ b/backend/routes/location.js
@@ -13,7 +13,7 @@ router.get('/', async (req, res) => {
 });
 
 // GET /location/:id (single location)
-router.get('/location/:id', async (req,res) => {
+router.get('/:id', async (req,res) => {
   const { id } = req.params;
   const singleLocation = await Location.findById(id);
   try {
@@ -21,20 +21,31 @@ router.get('/location/:id', async (req,res) => {
   } catch (error) {
       return res.status(500).json({message: "Couldn't retrieve the location"})
   }
-})
+});
 
 // POST /location
-router.post("/location", async (req, res) => {
+router.post("/", async (req, res) => {
   const locationToCreate = await Location.create(req.body);
   try {
       return res.status(201).json(locationToCreate);
   } catch (error) {
-      return res.status(500).json({message: "Couldn't create book"});
+      return res.status(500).json({message: "Couldn't create location"});
+  }
+});
+
+// PUT /location/:id
+router.put("/:id", async (req, res) => {
+  const { id } = req.params;
+  const locationToUpdate = await Location.findByIdAndUpdate(id, req.body, {new: true});
+  try {
+      return res.status(202).json(locationToUpdate);
+  } catch (error) {
+      return res.status(500).json({message: "Couldn't update the location"});
   }
 })
 
 // DELETE /location/:id
-router.delete("/location/:id", async (req, res) => {
+router.delete("/:id", async (req, res) => {
   const { id } = req.params;
   const locationToDelete = await Location.findByIdAndDelete(id)
   try {
@@ -42,6 +53,6 @@ router.delete("/location/:id", async (req, res) => {
   } catch (error) {
       return res.status(500).json({message: "Couldn't delete the location"})        
   }
-})
+});
 
 module.exports = router;


### PR DESCRIPTION
Have a basic functional API now for location data based on whatever we expect to account for, it can be easily modified for whatever we need to incorporate for any 3rd-party weather API.

I am including (attaching) the postman collection with this PR which I tested with (contains GET, POST, PUT, and DELETE endpoints).

Currently, the schema only accounts for data shaped like this as an example after it is stored in MongoDB:

`
    {
        "_id": "626b5740a9d1b503782c756c",
        "type": "Point",
        "coordinates": [
            -122.5,
            37.7
        ],
        "__v": 0,
        "name": "San Francisco"
    }
`

Here is the example data to use for inserting using the POST endpoint (You can use any name or coords here if needed):

`
{
    "type": "Point",
    "coordinates": [
        -122.5,
        37.7
    ],
    "name": "San Francisco"
}
`

with expecting location data as a point with coords.

[Weather App.postman_collection.zip](https://github.com/voidmaelstrom/weather-app/files/8587967/Weather.App.postman_collection.zip)